### PR TITLE
add some orcids to members, and fix front matter

### DIFF
--- a/_layouts/member.html
+++ b/_layouts/member.html
@@ -4,7 +4,7 @@ layout: default
 
 <h1>{{ page.title }}</h1>
 
-{%- include figure.html image=page.image -%}
+{%- include figure.html image=page.image height="400px" -%}
 
 <p class="center">
   {%- include role.html type=page.role text=true description=page.description -%}

--- a/_members/alex-lee.md
+++ b/_members/alex-lee.md
@@ -6,9 +6,11 @@ aliases:
   - Alex J. Lee
 image: images/team/alex.jpg
 role: phd
-email: alexjlee.21@gmail.com
-github: ajlee21
-twitter: localee_compact
+links:
+  orcid: 0000-0002-0208-3730
+  email: alexjlee.21@gmail.com
+  github: ajlee21
+  twitter: localee_compact
 ---
 
 Alexandra is a Ph.D. student in the Greene Lab through [Penn’s Genomics and Computational Biology (GCB) PhD Program](https://www.med.upenn.edu/gcb/).

--- a/_members/amy-campbell.md
+++ b/_members/amy-campbell.md
@@ -2,8 +2,9 @@
 name: Amy Campbell
 image: images/team/amy.jpg
 role: undergrad
-twitter: specific_ames
-github: amyecampbell
+links:
+  twitter: specific_ames
+  github: amyecampbell
 group: alum
 ---
 

--- a/_members/ariel-hippen.md
+++ b/_members/ariel-hippen.md
@@ -6,9 +6,11 @@ aliases:
   - Ariel A. Hippen
 image: images/team/ariel.jpg
 role: phd
-email: ariel.hippen@gmail.com
-github: arielah
-twitter: ariel_hippen
+links:
+  orcid: 0000-0001-9336-6543
+  email: ariel.hippen@gmail.com
+  github: arielah
+  twitter: ariel_hippen
 ---
 
 Ariel is a Ph.D. student through [Penn’s Genomics and Computational Biology (GCB) PhD program](https://www.med.upenn.edu/gcb/).

--- a/_members/ben-heil.md
+++ b/_members/ben-heil.md
@@ -2,10 +2,11 @@
 name: Ben Heil
 image: images/team/ben.jpg
 role: phd
-email: benjamin.heil@pennmedicine.upenn.edu
-website: https://autobencoder.com
-github: ben-heil
-twitter: autobencoder
+links:
+  email: benjamin.heil@pennmedicine.upenn.edu
+  home-page: https://autobencoder.com
+  github: ben-heil
+  twitter: autobencoder
 aliases:
     - Benjamin J. Heil
 ---

--- a/_members/ben-heil.md
+++ b/_members/ben-heil.md
@@ -3,6 +3,7 @@ name: Ben Heil
 image: images/team/ben.jpg
 role: phd
 links:
+  orcid: 0000-0002-2811-1031
   email: benjamin.heil@pennmedicine.upenn.edu
   home-page: https://autobencoder.com
   github: ben-heil

--- a/_members/brett-beaulieu-jones.md
+++ b/_members/brett-beaulieu-jones.md
@@ -2,7 +2,8 @@
 name: Brett Beaulieu-Jones
 image: images/team/brett.jpg
 role: phd
-website: http://wymsee.com/
+links:
+  home-page: http://wymsee.com/
 group: alum
 ---
 

--- a/_members/casey-greene.md
+++ b/_members/casey-greene.md
@@ -4,15 +4,17 @@ aliases:
   - Casey S. Greene
   - Casey Greene
   - Casey S Greene
-  - C.S. Greene 
+  - C.S. Greene
   - C. S. Greene
 image: images/team/casey.jpg
 role: pi
-website: https://greenelab.com
-email: casey.s.greene@cuanschutz.edu
-google: ETJoidYAAAAJ
-github: cgreene
-twitter: greenescientist
+links:
+  orcid: 0000-0001-8713-9213
+  home-page: https://greenelab.com
+  email: casey.s.greene@cuanschutz.edu
+  google-scholar: ETJoidYAAAAJ
+  github: cgreene
+  twitter: greenescientist
 ---
 
 Casey is a Professor in the Department of [Biochemistry and Molecular Genetics](https://medschool.cuanschutz.edu/biochemistry) and the founding Director of the [Center for Health AI](https://medschool.cuanschutz.edu/ai) in the [University of Colorado School of Medicine](https://medschool.cuanschutz.edu/).

--- a/_members/daniel-himmelstein.md
+++ b/_members/daniel-himmelstein.md
@@ -3,11 +3,12 @@ name: Daniel Himmelstein
 image: images/team/daniel.jpg
 role: postdoc
 group: alum
-website: https://dhimmel.com/
-email: daniel.himmelstein@gmail.com
-google: x9OwD9oAAAAJ
-github: dhimmel
-twitter: dhimmel
+links:
+  home-page: https://dhimmel.com/
+  email: daniel.himmelstein@gmail.com
+  google-scholar: x9OwD9oAAAAJ
+  github: dhimmel
+  twitter: dhimmel
 ---
 
 Daniel [joined](https://www.youtube.com/watch?v=goIOtEpE8Lc) the Greene Lab as a Postdoctoral Researcher in June 2016, after receiving his PhD in _Biological & Medical Informatics_ at UCSF.

--- a/_members/daniel-himmelstein.md
+++ b/_members/daniel-himmelstein.md
@@ -4,6 +4,7 @@ image: images/team/daniel.jpg
 role: postdoc
 group: alum
 links:
+  orcid: 0000-0002-3012-7446
   home-page: https://dhimmel.com/
   email: daniel.himmelstein@gmail.com
   google-scholar: x9OwD9oAAAAJ

--- a/_members/david-nicholson.md
+++ b/_members/david-nicholson.md
@@ -4,8 +4,10 @@ aliases:
   - David N. Nicholson
 image: images/team/david.jpg
 role: phd
-email: davnic@mail.med.upenn.edu
-github: danich1
+links:
+  orcid: 0000-0003-0002-5761
+  email: davnic@mail.med.upenn.edu
+  github: danich1
 ---
 
 David is a Ph.D. student in the Greene Lab through [Penn’s Genomics and Computational Biology (GCB) PhD Program](https://www.med.upenn.edu/gcb/).

--- a/_members/dongbo-hu.md
+++ b/_members/dongbo-hu.md
@@ -2,8 +2,9 @@
 name: Dongbo Hu
 image: images/team/dongbo.jpg
 role: programmer
-email: dongbo.hu@gmail.com
-github: dongbohu
+links:
+  email: dongbo.hu@gmail.com
+  github: dongbohu
 ---
 
 Dongbo used to be a chemist but was eventually attracted into computer science because of its elegance.

--- a/_members/greg-way.md
+++ b/_members/greg-way.md
@@ -2,8 +2,9 @@
 name: Greg Way
 image: images/team/greg.jpg
 role: phd
-website: http://www.gway-genomics.com/
-github: gwaygenomics
+links:
+  home-page: http://www.gway-genomics.com/
+  github: gwaygenomics
 group: alum
 ---
 

--- a/_members/halie-rando.md
+++ b/_members/halie-rando.md
@@ -7,10 +7,12 @@ aliases:
   - Halie Rando
   - Halie M Rando
 role: postdoc
-email: halie.rando@pennmedicine.upenn.edu
-google: gWtl3GwAAAAJ
-github: rando2
-twitter: tamefoxtime
+links:
+  orcid: 0000-0001-7688-1770
+  email: halie.rando@pennmedicine.upenn.edu
+  google-scholar: gWtl3GwAAAAJ
+  github: rando2
+  twitter: tamefoxtime
 ---
 
 Halie is a postdoctoral researcher who joined the Greene Lab in 2020.

--- a/_members/jaclyn-taroni.md
+++ b/_members/jaclyn-taroni.md
@@ -2,9 +2,10 @@
 name: Jaclyn Taroni
 image: images/team/jaclyn.jpg
 role: postdoc
-website: http://www.jaclyn-taroni.com/
-email: jaclyn.n.taroni@gmail.com
-github: jaclyn-taroni
+links:
+  home-page: http://www.jaclyn-taroni.com/
+  email: jaclyn.n.taroni@gmail.com
+  github: jaclyn-taroni
 group: alum
 ---
 

--- a/_members/jake-crawford.md
+++ b/_members/jake-crawford.md
@@ -2,10 +2,12 @@
 name: Jake Crawford
 image: images/team/jake.jpg
 role: phd
-website: http://jjc2718.github.io/
-email: jjc2718@gmail.com
-github: jjc2718
-twitter: jjc2718
+links:
+  orcid: 0000-0001-6207-0782
+  home-page: http://jjc2718.github.io/
+  email: jjc2718@gmail.com
+  github: jjc2718
+  twitter: jjc2718
 ---
 
 Jake is a Ph.D. student in the Greene Lab through [Penn's Genomics and Computational Biology (GCB) program](https://www.med.upenn.edu/gcb/).

--- a/_members/jie-tan.md
+++ b/_members/jie-tan.md
@@ -2,7 +2,8 @@
 name: Jie Tan
 image: images/team/jie.jpg
 role: phd
-email: jie.tan.gr@dartmouth.edu
+links:
+  email: jie.tan.gr@dartmouth.edu
 group: alum
 ---
 

--- a/_members/kurt-wheeler.md
+++ b/_members/kurt-wheeler.md
@@ -2,7 +2,8 @@
 name: Kurt Wheeler
 image: images/team/kurt.jpg
 role: programmer
-github: kurtwheeler
+links:
+  github: kurtwheeler
 group: alum
 ---
 

--- a/_members/matt-hyuck.md
+++ b/_members/matt-hyuck.md
@@ -2,7 +2,8 @@
 name: Matt Hyuck
 image: images/team/matt.jpg
 role: programmer
-email: mhuyck+greenelab@fgtech.com
+links:
+  email: mhuyck+greenelab@fgtech.com
 group: alum
 ---
 

--- a/_members/michael-zietz.md
+++ b/_members/michael-zietz.md
@@ -2,7 +2,8 @@
 name: Michael Zietz
 image: images/team/michael.jpg
 role: undergrad
-github: zietzm
+links:
+  github: zietzm
 group: alum
 ---
 

--- a/_members/milton-pividori.md
+++ b/_members/milton-pividori.md
@@ -5,10 +5,12 @@ aliases:
   - Milton D Pividori
 image: images/team/milton.jpg
 role: postdoc
-email: miltondp@gmail.com
-google: servJtkAAAAJ
-github: miltondp
-twitter: miltondp
+links:
+  orcid: 0000-0002-3035-4403
+  email: miltondp@gmail.com
+  google-scholar: servJtkAAAAJ
+  github: miltondp
+  twitter: miltondp
 ---
 
 Milton is a postdoctoral researcher who joined the GreeneLab in 2020.

--- a/_members/natalie-davidson.md
+++ b/_members/natalie-davidson.md
@@ -5,14 +5,16 @@ aliases:
   - Natalie R Davidson
 image: images/team/natalie_davidson.jpg
 role: postdoc
-email: natalie.davidson@cuanschutz.edu
-google: JZsqkOoAAAAJ
-github: nrosed
-twitter: n_rose_d
+links:
+  orcid: 0000-0002-1745-8072
+  email: natalie.davidson@cuanschutz.edu
+  google-scholar: JZsqkOoAAAAJ
+  github: nrosed
+  twitter: n_rose_d
 ---
 
 Natalie is a postdoctoral researcher who joined the GreeneLab in 2020.
 She received her PhD in Computational Biology and Medicine in 2019 from the Tri-Institutional Program for Computational Biology and Medicine in New York while conducting research at ETH Zürich's [Biomedical Informatics Lab](https://bmi.inf.ethz.ch/).
 During her PhD, she participated in the [International Cancer Genome Consortium](http://icgc.org/) where she performed integrative analyses across multiple transcriptional aberrations to identify cancer relevant genes and alteration patterns.
 
-Building upon her previous experience in analyzing large cancer cohorts, she aims to leverage freely availble datasets and integrate them with single-patient -omic data to help guide precision oncology. 
+Building upon her previous experience in analyzing large cancer cohorts, she aims to leverage freely availble datasets and integrate them with single-patient -omic data to help guide precision oncology.

--- a/_members/olivia-cheng.md
+++ b/_members/olivia-cheng.md
@@ -2,8 +2,9 @@
 name: Olivia Cheng
 image: images/team/olivia.jpg
 role: undergrad
-email: ocheng1@sas.upenn.edu
-github: ocheng1
+links:
+  email: ocheng1@sas.upenn.edu
+  github: ocheng1
 group: alum
 ---
 

--- a/_members/qiwen-hu.md
+++ b/_members/qiwen-hu.md
@@ -2,7 +2,8 @@
 name: Qiwen Hu
 image: images/team/qiwen.jpg
 role: postdoc
-website: https://dbmi.hms.harvard.edu/people/qiwen-hu
+links:
+  home-page: https://dbmi.hms.harvard.edu/people/qiwen-hu
 group: alum
 ---
 

--- a/_members/steven-foltz.md
+++ b/_members/steven-foltz.md
@@ -4,9 +4,10 @@ aliases:
   - Steven M. Foltz
 image: images/team/steven.jpg
 role: postdoc
-email: steven.foltz@pennmedicine.upenn.edu
-google: p8O2sHgAAAAJ
-github: envest
+links:
+  email: steven.foltz@pennmedicine.upenn.edu
+  google-scholar: p8O2sHgAAAAJ
+  github: envest
 ---
 
 Steven is a postdoctoral researcher who joined the [Childhood Cancer Data Lab](https://www.ccdatalab.org/) and the Greene Lab in 2020.

--- a/_members/vincent-rubinetti.md
+++ b/_members/vincent-rubinetti.md
@@ -2,10 +2,12 @@
 name: Vincent Rubinetti
 image: images/team/vince.jpg
 role: programmer
-website: https://www.vincentrubinetti.com/
-email: vince.rubinetti@gmail.com
-github: vincerubinetti
-twitter: vincerubinetti
+links:
+  orcid: 0000-0002-4655-3773
+  home-page: https://www.vincentrubinetti.com/
+  email: vince.rubinetti@gmail.com
+  github: vincerubinetti
+  twitter: vincerubinetti
 ---
 
 Vince is a staff frontend developer in the Greene Lab.

--- a/_members/yoson.park.md
+++ b/_members/yoson.park.md
@@ -2,7 +2,8 @@
 name: Yoson Park
 image: images/team/yoson.jpg
 role: postdoc
-github: ypar
+links:
+  github: ypar
 group: alum
 ---
 


### PR DESCRIPTION
- adds orcids for most/all current lab members
- fixes member front matter links to be under `links` key instead of at root. this was changed in the most recent big refactor of the lab website template, but I forgot to change the member front matters here