### PR TITLE
filter casey orcid by defined title

### DIFF
--- a/_includes/citation-id.html
+++ b/_includes/citation-id.html
@@ -1,0 +1,1 @@
+<div>{{ include.id }}</div>

--- a/_includes/citation-id.html
+++ b/_includes/citation-id.html
@@ -1,1 +1,2 @@
+{{ " " }}
 <div>{{ include.id }}</div>

--- a/_members/casey-greene.md
+++ b/_members/casey-greene.md
@@ -31,7 +31,7 @@ The overarching theme of his work has been the development and evaluation of met
 
 {% capture content %}
 
-{% include list.html data="citations" component="citation" filters="member: casey-greene" %}
+{% include list.html data="citations" component="citation" filters="member: casey-greene, title: .+" %}
 
 {% endcapture %}
 

--- a/_members/casey-greene.md
+++ b/_members/casey-greene.md
@@ -36,3 +36,11 @@ The overarching theme of his work has been the development and evaluation of met
 {% endcapture %}
 
 {% include grid.html content=content %}
+
+{% capture content %}
+
+{% include list.html data="citations" component="citation-id" filters="member: casey-greene, title: " %}
+
+{% endcapture %}
+
+{% include grid.html content=content %}

--- a/_members/casey-greene.md
+++ b/_members/casey-greene.md
@@ -27,7 +27,7 @@ The overarching theme of his work has been the development and evaluation of met
 
 {% include float.html clear=true %}
 
-## All papers under Casey's ORCID:
+## All publications under Casey's ORCID
 
 {% capture content %}
 
@@ -43,4 +43,8 @@ The overarching theme of his work has been the development and evaluation of met
 
 {% endcapture %}
 
+## Other publications
+
 {% include grid.html content=content %}
+
+## Select publications


### PR DESCRIPTION
Based on comments in this issue:
https://github.com/greenelab/lab-website-template/issues/186

Currently, there's a bunch of `[no title info]` entries at the bottom:
https://greenelab.com/members/casey-greene.html
Due to ORCID returning a lot of paper ID types that Manubot can't cite. This filters out ones that don't have defined titles. v1.1.3 of the template also adds a small commented out `continue` line in the cite process script that allows users to not include non-citable ids in the output if they want.